### PR TITLE
remove non existing modules from root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,10 +39,7 @@
     <module>spin/dataformat-configuration-global</module>
     <module>spin/dataformat-configuration-in-process-application</module>
     <module>spring-boot-starter/example-autodeployment</module>
-    <module>spring-boot-starter/example-cloud</module>
-    <module>spring-boot-starter/example-koala</module>
     <module>spring-boot-starter/example-simple</module>
-    <module>spring-boot-starter/example-simple-760</module>
     <module>spring-boot-starter/example-twitter</module>
     <module>spring-boot-starter/example-war</module>
     <module>spring-boot-starter/example-web</module>


### PR DESCRIPTION
I found that some spring boot examples (koala, cloud, simple-760) are not existing anymore but still referenced in the root pom. Running mvn clean install on project root fails due to missing modules.