### PR TITLE
CAM-10278 - Rest controller for starting process is added

### DIFF
--- a/spring-boot-starter/example-webapp/README.md
+++ b/spring-boot-starter/example-webapp/README.md
@@ -45,3 +45,5 @@ You can build the application with `mvn clean install` and then run it with `jav
 
 Then you can access Camunda Webapps in browser: `http://localhost:8080` (provide login/password from `application.yaml`)
 
+You can start `bpmn/sample.bpmn` process by simply sending a `Http.GET` request to `http://localhost:8080/process/start/Sample`
+

--- a/spring-boot-starter/example-webapp/pom.xml
+++ b/spring-boot-starter/example-webapp/pom.xml
@@ -47,6 +47,12 @@
       <artifactId>jaxb-impl</artifactId>
       <version>2.2.3</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>

--- a/spring-boot-starter/example-webapp/pom.xml
+++ b/spring-boot-starter/example-webapp/pom.xml
@@ -48,11 +48,6 @@
       <version>2.2.3</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <optional>true</optional>
-    </dependency>
   </dependencies>
 
   <build>

--- a/spring-boot-starter/example-webapp/src/main/java/org/camunda/bpm/spring/boot/example/webapp/controller/ProcessController.java
+++ b/spring-boot-starter/example-webapp/src/main/java/org/camunda/bpm/spring/boot/example/webapp/controller/ProcessController.java
@@ -1,9 +1,10 @@
 package org.camunda.bpm.spring.boot.example.webapp.controller;
 
-import lombok.extern.slf4j.Slf4j;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.task.Task;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,9 +12,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
-@Slf4j
 @RestController
 public class ProcessController {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Autowired
     private RuntimeService runtimeService;
@@ -24,11 +26,11 @@ public class ProcessController {
     @GetMapping("/process/start/{processKey}")
     public ResponseEntity startProcess(@PathVariable("processKey") String processKey) {
         String processInstanceId = runtimeService.startProcessInstanceByKey(processKey).getProcessInstanceId();
-        log.info("started instance with id: {}", processInstanceId);
+        logger.info("started instance with id: {}", processInstanceId);
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstanceId).singleResult();
         taskService.complete(task.getId());
-        log.info("completed task: {}", task);
+        logger.info("completed task: {}", task);
 
         return ResponseEntity.ok(HttpStatus.OK);
     }

--- a/spring-boot-starter/example-webapp/src/main/java/org/camunda/bpm/spring/boot/example/webapp/controller/ProcessController.java
+++ b/spring-boot-starter/example-webapp/src/main/java/org/camunda/bpm/spring/boot/example/webapp/controller/ProcessController.java
@@ -1,0 +1,36 @@
+package org.camunda.bpm.spring.boot.example.webapp.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.TaskService;
+import org.camunda.bpm.engine.task.Task;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+public class ProcessController {
+
+    @Autowired
+    private RuntimeService runtimeService;
+
+    @Autowired
+    private TaskService taskService;
+
+    @GetMapping("/process/start/{processKey}")
+    public ResponseEntity startProcess(@PathVariable("processKey") String processKey) {
+        String processInstanceId = runtimeService.startProcessInstanceByKey(processKey).getProcessInstanceId();
+        log.info("started instance with id: {}", processInstanceId);
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstanceId).singleResult();
+        taskService.complete(task.getId());
+        log.info("completed task: {}", task);
+
+        return ResponseEntity.ok(HttpStatus.OK);
+    }
+
+}

--- a/spring-boot-starter/example-webapp/src/test/java/org/camunda/bpm/spring/boot/example/webapp/RestCallTest.java
+++ b/spring-boot-starter/example-webapp/src/test/java/org/camunda/bpm/spring/boot/example/webapp/RestCallTest.java
@@ -1,0 +1,37 @@
+package org.camunda.bpm.spring.boot.example.webapp;
+
+import org.camunda.bpm.spring.boot.example.webapp.controller.ProcessController;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {WebappExampleApplication.class, ProcessController.class}, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DirtiesContext
+public class RestCallTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RestCallTest.class);
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    @Test
+    public void startProcess() {
+        LOGGER.info("Sending Http.GET request to /process/start/Sample ...");
+        ResponseEntity<String> entity = testRestTemplate.getForEntity("/process/start/Sample", String.class);
+        final String body = entity.getBody();
+        assertTrue("Starting process failed " + body, body.equals("\"OK\""));
+        LOGGER.info("body: {}", body);
+    }
+
+
+}


### PR DESCRIPTION
In _spring-boot-starter.example-webapp_ module, I have added a rest controller to support starting the processes through _Http.GET_ request. Also, I have added _Lombok_ library to use its logging mechanism.