### PR TITLE
CAM-12163: bump Spring from 4 to 5 in soap-start example

### DIFF
--- a/startevent/soap-cxf-server-start/pom.xml
+++ b/startevent/soap-cxf-server-start/pom.xml
@@ -15,8 +15,8 @@
     <cxf.version>3.3.6</cxf.version>
     <cxf.xjc.version>3.0.5</cxf.xjc.version>
     <cglib.version>2.2.2</cglib.version>
-    <spring.version>4.3.24.RELEASE</spring.version>
-    <spring.security.version>4.2.12.RELEASE</spring.security.version>
+    <spring.version>5.2.8.RELEASE</spring.version>
+    <spring.security.version>5.3.3.RELEASE</spring.security.version>
     <logback.version>1.1.3</logback.version>
     <slf4j.version>1.7.12</slf4j.version>
     <!-- test -->

--- a/startevent/soap-cxf-server-start/src/main/resources/properties/users.properties
+++ b/startevent/soap-cxf-server-start/src/main/resources/properties/users.properties
@@ -1,2 +1,2 @@
 #basic auth credentials
-user=password,ROLE_WS
+user={noop}password,ROLE_WS


### PR DESCRIPTION
- The latest Spring Security 5 version fixes security issues

related to CAM-12163