### PR TITLE
CAM-12347: chore(release): update deployment examples to 7.14.0

### DIFF
--- a/deployment/ejb-pa/pom.xml
+++ b/deployment/ejb-pa/pom.xml
@@ -8,7 +8,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <version.camunda>7.13.0</version.camunda>
+    <version.camunda>7.14.0</version.camunda>
     <version.java-ee-specs>3.0.1.Final</version.java-ee-specs>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/deployment/embedded-spring-rest/pom.xml
+++ b/deployment/embedded-spring-rest/pom.xml
@@ -9,7 +9,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <version.camunda>7.13.0</version.camunda>
+    <version.camunda>7.14.0</version.camunda>
     <version.spring>4.3.24.RELEASE</version.spring>
     <version.resteasy-jaxrs>3.10.0.Final</version.resteasy-jaxrs>
     <version.h2>1.3.171</version.h2>

--- a/deployment/servlet-pa/pom.xml
+++ b/deployment/servlet-pa/pom.xml
@@ -8,7 +8,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <version.camunda>7.13.0</version.camunda>
+    <version.camunda>7.14.0</version.camunda>
     <version.servlet-api.javax>3.0.1</version.servlet-api.javax>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/deployment/spring-boot/pom.xml
+++ b/deployment/spring-boot/pom.xml
@@ -20,7 +20,7 @@
   </parent>
 
   <properties>
-    <version.camunda>7.13.0</version.camunda>
+    <version.camunda>7.14.0</version.camunda>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
   </properties>

--- a/deployment/spring-servlet-pa-tomcat/pom.xml
+++ b/deployment/spring-servlet-pa-tomcat/pom.xml
@@ -8,7 +8,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <camunda.version>7.13.0</camunda.version>
+    <camunda.version>7.14.0</camunda.version>
     <spring.version>4.3.24.RELEASE</spring.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/deployment/spring-servlet-pa-wildfly/pom.xml
+++ b/deployment/spring-servlet-pa-wildfly/pom.xml
@@ -8,9 +8,9 @@
   <version>1.0-SNAPSHOT</version>
   
   <properties>
-    <version.camunda>7.13.0</version.camunda>
+    <version.camunda>7.14.0</version.camunda>
     <version.spring>4.3.24.RELEASE</version.spring>
-    <version.wildfly>19.0.0.Final</version.wildfly>
+    <version.wildfly>20.0.1.Final</version.wildfly>
     <version.servlet-api.javax>3.0.1</version.servlet-api.javax>
 
     <version.wildfly.container.adapter>2.2.0.Final</version.wildfly.container.adapter>

--- a/deployment/spring-wildfly-non-pa/pom.xml
+++ b/deployment/spring-wildfly-non-pa/pom.xml
@@ -9,7 +9,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <camunda.version>7.13.0</camunda.version>
+    <camunda.version>7.14.0</camunda.version>
     <spring.version>4.3.24.RELEASE</spring.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
Related to CAM-12347

Note:
Tested with `7.14.0-alpha4`, all examples work as expected.