### PR TITLE
chore(tasklist): adjust Examples to new Plugin system

### DIFF
--- a/tasklist/cats-plugin/README.md
+++ b/tasklist/cats-plugin/README.md
@@ -1,9 +1,9 @@
-Javascript Only Plugin for Camunda tasklist
+Javascript Only Plugin for Camunda Tasklist
 =================================
 
 This example shows how to develop a Tasklist plugin without the need to register it with the Camunda Platform server. It makes use of the `customScript` property of the webapp configurations.
 
-Built and tested against Camunda Platform version `7.14.0`.
+Built and tested against Camunda Platform version `7.15.0`.
 
 ![Screenshot](screenshot.png)
 
@@ -17,16 +17,9 @@ Add the following content to the `customScripts` object in the `app/tasklist/scr
 
 ```
   // …
-  customScripts: {
-    ngDeps: ['tasklist.cats'],
-
-    deps: ['cats'],
-
-    // RequreJS path definitions
-    paths: {
-      'cats': 'scripts/cats'
-    }
-  },
+  customScripts: [
+    'scripts/cats'
+  ],
   // …
 ```
 

--- a/tasklist/cats-plugin/cats.js
+++ b/tasklist/cats-plugin/cats.js
@@ -15,18 +15,15 @@
  * limitations under the License.
  */
 
-define(['angular'], function(angular) {
 
-  var ngModule = angular.module('tasklist.cats', []);
-
-  ngModule.config(['ViewsProvider', function(ViewsProvider) {
-    ViewsProvider.registerDefaultView('tasklist.task.detail', {
-      label: 'Cats!',
-      id: 'cockpit.cats',
-      priority: 9001,
-      template: '<h1>Cats!</h1><img src="http://thecatapi.com/api/images/get?size=medium" width="400" />'
-    });
-  }]);
-
-  return ngModule;
-});
+export default {
+  id: 'tasklist.cats',
+  pluginPoint: 'tasklist.task.detail',
+  priority: 9001,
+  render: (node) => {
+    node.innerHTML = '<h1>Cats!</h1><img src="http://thecatapi.com/api/images/get?size=medium" width="400" />';
+  },
+  properties: {
+    label: 'Cats!'
+  }
+}

--- a/tasklist/jquery-34-behavior/README.md
+++ b/tasklist/jquery-34-behavior/README.md
@@ -5,7 +5,7 @@ This example enables JQuery 3.4 behavior in the Camunda Webapps 7.14+ . It makes
 
 You can read more about the JQuery 3.5 release in the [JQuery release blog](https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/).
 
-Built and tested against Camunda Platform version `7.14.0`.
+Built and tested against Camunda Platform version `7.15.0`.
 
 
 Integrate into Camunda Webapp
@@ -19,16 +19,9 @@ Add the following content to the `customScripts` object in the `app/tasklist/scr
 
 ```
   // …
-  customScripts: {
-    ngDeps: [],
-
-    deps: ['jquery-patch'],
-
-    // RequireJS path definitions
-    paths: {
-      'jquery-patch': 'scripts/jquery-patch'
-    }
-  }
+  customScripts: [
+    'scripts/jquery-patch'
+  ]
   // …
 ```
 

--- a/tasklist/jquery-34-behavior/jquery-patch.js
+++ b/tasklist/jquery-34-behavior/jquery-patch.js
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-define(['jQuery'], function(jQuery) {
-  var rxhtmlTag = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([a-z][^\/\0>\x20\t\r\n\f]*)[^>]*)\/>/gi;
-  jQuery.htmlPrefilter = function( html ) {
-      return html.replace( rxhtmlTag, "<$1></$2>" );
-  };
-});
+var jQuery = window.$;
+
+var rxhtmlTag = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([a-z][^\/\0>\x20\t\r\n\f]*)[^>]*)\/>/gi;
+jQuery.htmlPrefilter = function( html ) {
+    return html.replace( rxhtmlTag, "<$1></$2>" );
+};

--- a/usertask/task-form-embedded-react/README.md
+++ b/usertask/task-form-embedded-react/README.md
@@ -6,18 +6,12 @@ React is a popular library to build user interfaces. If you want to use react to
 ## Overview
 ### How can I add React to my Tasklist?
   1. Download [React](https://unpkg.com/react@16.8.6/umd/react.development.js) and [reactDOM](https://unpkg.com/react-dom@16.8.6/umd/react-dom.development.js) into the `app/tasklist/scripts/react` of your webapp.
-  2. Add [loadReact.js](config/react/loadReact.js) to the same folder. This will add React and ReactDOM to the global scope
-  3. Add everything as a custom script in `app/tasklist/scripts/config.js`. If you use the production build of react, change the path accordingly.
+  2. Add [loadReact.js](config/react/loadReact.js) to the same folder. This will add React and ReactDOM to the global scope. If you use the production build of react, adjust the imports accordingly. 
+  3. Add the loader as a custom script in `app/tasklist/scripts/config.js`. 
   ```javascript
-    customScripts: {
-      ngDeps: [],
-      deps: ['loadReact', 'react', 'react-dom'],
-      paths: {
-        'loadReact': 'scripts/react/loadReact',
-        'react': 'scripts/react/react.development',
-        'react-dom': 'scripts/react/react-dom.development'
-      }
-    }
+    customScripts: [
+      'scripts/react/loadReact.js'
+    ]
   ```
 That's it, you can now use react in your custom forms.
 

--- a/usertask/task-form-embedded-react/config/config.js
+++ b/usertask/task-form-embedded-react/config/config.js
@@ -15,18 +15,10 @@
  * limitations under the License.
  */
 
-window.camTasklistConf = {
+export default {
   // // custom libraries and scripts loading and initialization,
   // // see: http://docs.camunda.org/guides/user-guide/#tasklist-customizing-custom-scripts
-  customScripts: {
-    ngDeps: [],
-    // RequireJS configuration for a complete configuration documentation see:
-    // http://requirejs.org/docs/api.html#config
-    deps: ['loadReact', 'react', 'react-dom'],
-    paths: {
-      'loadReact': 'scripts/react/loadReact',
-      'react': 'scripts/react/react.development',
-      'react-dom': 'scripts/react/react-dom.development'
-    }
-  }
+  customScripts: [
+    'scripts/react/loadReact',
+  ]
 };

--- a/usertask/task-form-embedded-react/config/react/loadReact.js
+++ b/usertask/task-form-embedded-react/config/react/loadReact.js
@@ -15,9 +15,5 @@
  * limitations under the License.
  */
 
- require( ['react', 'react-dom'],
-  function(React, ReactDOM) {
-    window.React = React;
-    window.ReactDOM = ReactDOM;
-  }
-);
+window.React = import('./react.development.js');
+window.ReactDOM = import('./react-dom.development.js');


### PR DESCRIPTION
related to CAM-12594

I am not sure if adjusting the "Built and tested against Camunda Platform version" is the correct way to go. I want to avoid confusion if someone visits the master branch before 7.15 is released.