### PR TITLE
Bump version of XTaC & XTaC Starter on 7.15.0-release branch

### DIFF
--- a/clients/java/dataformat/pom.xml
+++ b/clients/java/dataformat/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-external-task-client</artifactId>
-      <version>1.4.1</version>
+      <version>7.15.0</version>
     </dependency>
     
     <dependency>

--- a/clients/java/loan-granting/pom.xml
+++ b/clients/java/loan-granting/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-external-task-client</artifactId>
-      <version>1.4.1</version>
+      <version>7.15.0</version>
     </dependency>
 
     <dependency>

--- a/clients/java/order-handling/pom.xml
+++ b/clients/java/order-handling/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-external-task-client</artifactId>
-      <version>1.4.1</version>
+      <version>7.15.0</version>
     </dependency>
 
     <dependency>

--- a/spring-boot-starter/external-task-client/loan-granting-spring-boot-webapp/pom.xml
+++ b/spring-boot-starter/external-task-client/loan-granting-spring-boot-webapp/pom.xml
@@ -11,7 +11,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <version.camunda>7.15.0-SNAPSHOT</version.camunda>
+    <version.camunda>7.15.0</version.camunda>
     <java.version>1.8</java.version>
     <spring.boot.version>2.4.3</spring.boot.version>
     <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>

--- a/spring-boot-starter/external-task-client/loan-granting-spring/pom.xml
+++ b/spring-boot-starter/external-task-client/loan-granting-spring/pom.xml
@@ -8,7 +8,7 @@
   <version>0.0.1-SNAPSHOT</version>
 
   <properties>
-    <version.camunda>7.15.0-SNAPSHOT</version.camunda>
+    <version.camunda>7.15.0</version.camunda>
     <version.spring.framework>5.2.8.RELEASE</version.spring.framework>
     <version.slf4j>1.7.12</version.slf4j>
     <version.glassfish.jaxb>2.3.3</version.glassfish.jaxb>

--- a/spring-boot-starter/external-task-client/order-handling-spring-boot/pom.xml
+++ b/spring-boot-starter/external-task-client/order-handling-spring-boot/pom.xml
@@ -21,7 +21,7 @@
       <dependency>
         <groupId>org.camunda.bpm</groupId>
         <artifactId>camunda-bom</artifactId>
-        <version>7.15.0-SNAPSHOT</version>
+        <version>7.15.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/spring-boot-starter/external-task-client/request-interceptor-spring-boot/pom.xml
+++ b/spring-boot-starter/external-task-client/request-interceptor-spring-boot/pom.xml
@@ -21,7 +21,7 @@
       <dependency>
         <groupId>org.camunda.bpm</groupId>
         <artifactId>camunda-bom</artifactId>
-        <version>7.15.0-SNAPSHOT</version>
+        <version>7.15.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
@yanavasileva, these version bumps were not spotted by the GitHub action since they were newly introduced and didn't have the 7.14.0 version. I wanted to avoid that there are not working examples on master. This is why I didn't set them to 7.14.0 when adding them to this repo. Maybe you can merge this PR into the `7.15.0-release` branch.