### PR TITLE
chore(quarkus-extension): add explicitly repository snapshots enabled

### DIFF
--- a/quarkus-extension/datasource-example/pom.xml
+++ b/quarkus-extension/datasource-example/pom.xml
@@ -141,4 +141,18 @@
       </plugin>
     </plugins>
   </build>
+
+  <repositories>
+    <repository>
+      <id>camunda-nexus</id>
+      <name>Camunda Platform Maven Repository</name>
+      <url>https://artifacts.camunda.com/artifactory/public/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 </project>

--- a/quarkus-extension/simple-rest-example/pom.xml
+++ b/quarkus-extension/simple-rest-example/pom.xml
@@ -95,4 +95,18 @@
       </plugin>
     </plugins>
   </build>
+
+  <repositories>
+    <repository>
+      <id>camunda-nexus</id>
+      <name>Camunda Platform Maven Repository</name>
+      <url>https://artifacts.camunda.com/artifactory/public/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 </project>

--- a/quarkus-extension/spin-plugin-example/pom.xml
+++ b/quarkus-extension/spin-plugin-example/pom.xml
@@ -110,4 +110,18 @@
       </plugin>
     </plugins>
   </build>
+
+  <repositories>
+    <repository>
+      <id>camunda-nexus</id>
+      <name>Camunda Platform Maven Repository</name>
+      <url>https://artifacts.camunda.com/artifactory/public/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 </project>


### PR DESCRIPTION
adding repo config as temporary workaround as the examples cannot be built with a snapshot version of the quarkus extension