### PR TITLE
chore(deployment): adjust deployment examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ If you clone this repository, use the checkout commands to access the sources fo
 | ----------------------------------------------------------------------------------------------|-----------------------|---------------------------|
 | [Process Application - Servlet](deployment/servlet-pa)                                        | All                   | War, Servlet              |
 | [Process Application - EJB](deployment/ejb-pa)                                                | JavaEE Containers     | Ejb, War                  |
+| [Process Application - Jakarta EJB](deployment/ejb-pa-jakarta)                                | Jakarta EE Containers | Ejb, War                  |
 | [Process Application - Spring Servlet - WildFly](deployment/spring-servlet-pa-wildfly)        | WildFly               | Spring, Servlet, War      |
 | [Process Application - Spring Servlet - Embedded Tomcat](deployment/spring-servlet-pa-tomcat) | Tomcat                | Spring, Servlet, War      |
 | [Embedded Spring with embedded REST](deployment/embedded-spring-rest)                         | vanilla Apache Tomcat | Spring, Rest, Embedded    |

--- a/deployment/ejb-pa-jakarta/README.md
+++ b/deployment/ejb-pa-jakarta/README.md
@@ -1,0 +1,14 @@
+# Jakarta EJB Process Application Example
+
+This example demonstrates how to deploy a Jakarta EJB process application.
+
+## How to use it
+
+1. Build it with Maven.
+2. Deploy it to a `camunda-bpm-platform` distro of your own choice that supports Jakarta EE 9+ EJBs (e.g. WildFly).
+3. Wait a minute.
+4. Watch out for this console log:
+
+```bash
+This is a @Stateless Ejb component invoked from a BPMN 2.0 process.
+```

--- a/deployment/ejb-pa-jakarta/pom.xml
+++ b/deployment/ejb-pa-jakarta/pom.xml
@@ -1,0 +1,51 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.camunda.bpm.quickstart</groupId>
+  <artifactId>camunda-quickstart-ejb-pa-jakarta</artifactId>
+  <packaging>war</packaging>
+  <name>Camunda Platform - Quickstarts - Jakarta Ejb Process Application</name>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <version.camunda>7.19.0</version.camunda>
+    <version.jakarta-ee-specs>10.0.0</version.jakarta-ee-specs>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <failOnMissingWebXml>false</failOnMissingWebXml>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.camunda.bpm</groupId>
+      <artifactId>camunda-engine</artifactId>
+      <version>${version.camunda}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.camunda.bpm.javaee</groupId>
+      <artifactId>camunda-ejb-client-jakarta</artifactId>
+      <version>${version.camunda}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.camunda.bpm</groupId>
+      <artifactId>camunda-engine-cdi-jakarta</artifactId>
+      <version>${version.camunda}</version>
+    </dependency>
+
+    <dependency>
+      <!-- Jakarta EE Specification -->
+      <groupId>jakarta.platform</groupId>
+      <artifactId>jakarta.jakartaee-api</artifactId>
+      <version>${version.jakarta-ee-specs}</version>
+      <type>pom</type>
+      <scope>provided</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/deployment/ejb-pa-jakarta/src/main/java/org/camunda/bpm/quickstart/ejb/EjbJavaDelegate.java
+++ b/deployment/ejb-pa-jakarta/src/main/java/org/camunda/bpm/quickstart/ejb/EjbJavaDelegate.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.quickstart.ejb;
+
+import java.util.logging.Logger;
+
+import jakarta.ejb.Stateless;
+import jakarta.inject.Named;
+
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.JavaDelegate;
+
+/**
+ * This is an Ejb which is invoked form a Service task
+ *
+ */
+@Named("exampleBean")
+@Stateless
+public class EjbJavaDelegate implements JavaDelegate {
+
+  private final static Logger LOGGER = Logger.getLogger(EjbJavaDelegate.class.getName());
+
+  public void execute(DelegateExecution execution) {
+
+    LOGGER.info("\n\n\n This is a @Stateless Ejb component invoked from a BPMN 2.0 process \n\n\n");
+
+  }
+
+}

--- a/deployment/ejb-pa-jakarta/src/main/java/org/camunda/bpm/quickstart/ejb/EjbProcessStarter.java
+++ b/deployment/ejb-pa-jakarta/src/main/java/org/camunda/bpm/quickstart/ejb/EjbProcessStarter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.quickstart.ejb;
+
+import jakarta.ejb.DependsOn;
+import jakarta.ejb.Schedule;
+import jakarta.ejb.Singleton;
+import jakarta.ejb.Startup;
+import jakarta.inject.Inject;
+
+import org.camunda.bpm.engine.RuntimeService;
+
+/**
+ * Ejb which is automatically started when the application is deployed and creates a new process instance
+ *
+ */
+@Startup
+@Singleton
+@DependsOn("DefaultEjbProcessApplication")
+public class EjbProcessStarter {
+
+  @Inject
+  private RuntimeService runtimeService;
+
+  @Schedule(hour="*", minute="*")
+  public void startProcessInstance() {
+
+    runtimeService.startProcessInstanceByKey("testResolveBean");
+
+  }
+
+}

--- a/deployment/ejb-pa-jakarta/src/main/resources/EjbExpressionResolvingTest.testResolveBean.bpmn
+++ b/deployment/ejb-pa-jakarta/src/main/resources/EjbExpressionResolvingTest.testResolveBean.bpmn
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" targetNamespace="Examples" exporter="Camunda Modeler" exporterVersion="4.7.0">
+  <process id="testResolveBean" isExecutable="true">
+    <startEvent id="theStart" name="Start" />
+    <endEvent id="endevent1" name="End" />
+    <serviceTask id="servicetask1" name="Service Task" camunda:delegateExpression="${exampleBean}" />
+    <sequenceFlow id="flow11" name="" sourceRef="servicetask1" targetRef="endevent1" />
+    <sequenceFlow id="flow12" name="" sourceRef="theStart" targetRef="servicetask1" />
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_testDeployProcessArchive">
+    <bpmndi:BPMNPlane id="BPMNPlane_testDeployProcessArchive" bpmnElement="testResolveBean">
+      <bpmndi:BPMNEdge id="BPMNEdge_flow12" bpmnElement="flow12">
+        <omgdi:waypoint x="195" y="107" />
+        <omgdi:waypoint x="240" y="107" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_flow11" bpmnElement="flow11">
+        <omgdi:waypoint x="345" y="107" />
+        <omgdi:waypoint x="382" y="107" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_theStart" bpmnElement="theStart">
+        <omgdc:Bounds x="160" y="90" width="35" height="35" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="166" y="125" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_servicetask1" bpmnElement="servicetask1">
+        <omgdc:Bounds x="240" y="80" width="105" height="55" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_endevent1" bpmnElement="endevent1">
+        <omgdc:Bounds x="382" y="90" width="35" height="35" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="390" y="125" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/deployment/ejb-pa-jakarta/src/main/webapp/WEB-INF/beans.xml
+++ b/deployment/ejb-pa-jakarta/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,5 @@
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0" bean-discovery-mode="all">
+</beans>

--- a/deployment/ejb-pa/README.md
+++ b/deployment/ejb-pa/README.md
@@ -1,14 +1,21 @@
-EJB Process Application Example
-=================================
+# EJB Process Application Example
 
 This example demonstrates how to deploy an EJB process application.
 
-How to use it
------------------------------
+## How to use it
 
-1. Checkout the project with Git;
-2. Import the project into your IDE;
-3. Build it with Maven;
-4. Deploy it to a `camunda-bpm-platform` distro of your own choice, that supports EJBs (Wildfly);
-5. Wait a minute;
-6. Check the console if you can find: "This is a @Stateless Ejb component invoked from a BPMN 2.0 process".
+1. Build it with Maven.
+2. Deploy it to a `camunda-bpm-platform` distro of your own choice that supports Java EE 6 to 8 EJBs (e.g. WildFly 26 and below, install as described [here][1]).
+3. Wait a minute.
+4. Watch out for this console log:
+
+```bash
+This is a @Stateless Ejb component invoked from a BPMN 2.0 process.
+```
+
+## Moving to Jakarta API
+
+If you would like to deploy this on a Jakarta EE 9+ server like WildFly 27 and beyond, have a look at the [Jakarta EJB example][2].
+
+[1]: https://docs.camunda.org/manual/latest/installation/full/jboss/manual/
+[2]: /deployment/ejb-pa-jakarta

--- a/deployment/embedded-spring-rest/README.md
+++ b/deployment/embedded-spring-rest/README.md
@@ -132,10 +132,6 @@ Reference all required libraries in pom.xml:
 
 ## How to use it?
 
-1. Build it with Maven
+1. Build it with Maven.
 2. Deploy it to a vanilla Apache Tomcat server, NOT the prepackaged distribution which can be downloaded from https://camunda.com!
-3. Access the REST Endpoint:
-[http://localhost:8080/camunda-quickstart-embedded-spring-rest-1.0-SNAPSHOT/engine/default/process-definition][1]
-
-
-[1]: http://localhost:8080/camunda-quickstart-embedded-spring-rest-1.0-SNAPSHOT/engine/default/process-definition
+3. Access the [REST Endpoint](http://localhost:8080/camunda-quickstart-embedded-spring-rest-1.0-SNAPSHOT/engine/default/process-definition)

--- a/deployment/embedded-spring-rest/pom.xml
+++ b/deployment/embedded-spring-rest/pom.xml
@@ -10,7 +10,7 @@
 
   <properties>
     <version.camunda>7.19.0</version.camunda>
-    <version.spring>5.3.22</version.spring>
+    <version.spring>5.3.26</version.spring>
     <version.resteasy-jaxrs>3.15.3.Final</version.resteasy-jaxrs>
     <version.h2>2.1.214</version.h2>
     <version.slf4j>1.7.32</version.slf4j>

--- a/deployment/servlet-pa/README.md
+++ b/deployment/servlet-pa/README.md
@@ -1,14 +1,24 @@
-Simple Servlet Process Application Example
-==========================================
+# Simple Servlet Process Application Example
 
 This example demonstrates how to deploy a simple servlet process application.
 
-How to use it
------------------------------
+## How to use it
 
-1. Checkout the project with Git;
-2. Import the project into your IDE;
-3. Build it with Maven;
-4. Deploy it to a `camunda-bpm-platform` distro of your choice;
-6. Check the console if you can find: "Service Task 'Example ServiceTask' is invoked!".
+1. Build it with Maven.
+2. Deploy it to a `camunda-bpm-platform` distro of your choice (for WildFly, use version 26 or below, install as described [here][1]).
+3. Watch out for this console log:
 
+```bash
+Service Task 'Example ServiceTask' is invoked!
+```
+
+## Moving to Jakarta API
+
+If you would like to deploy this on a Jakarta EE 9+ server like WildFly 27 and beyond, perform the following steps:
+
+1. Replace the `javax.servlet-api` dependency with a Jakarta equivalent, i.e. `jakarta.servlet-api`.
+2. Replace all occurrences of `javax.servlet` in the code with `jakarta.servlet`, e.g. in `ExampleProcessApplication`.
+3. Repalce all occurrences of `org.camunda.bpm.application.impl.ServletProcessApplication` with `org.camunda.bpm.application.impl.JakartaServletProcessApplication`, e.g. in `ExampleProcessApplication`.
+4. Build and deploy as outlined above.
+
+[1]: https://docs.camunda.org/manual/latest/installation/full/jboss/manual/

--- a/deployment/spring-servlet-pa-tomcat/README.md
+++ b/deployment/spring-servlet-pa-tomcat/README.md
@@ -86,17 +86,17 @@ This will start the embedded tomcat server.
 [INFO] [talledLocalContainer] INFO: ENGINE-08046 Found Camunda Platform configuration in CATALINA_BASE/CATALINA_HOME conf directory [./target/cargo/configurations/tomcat9x/conf/bpm-platform.xml] at './target/cargo/configurations/tomcat9x/conf/bpm-platform.xml'
 ...
 [INFO] [talledLocalContainer] INFO: ENGINE-07015 Detected @ProcessApplication class 'org.camunda.bpm.example.spring.servlet.pa.SpringServletProcessApplication'
-[INFO] [talledLocalContainer] Sep 23, 2021 9:35:01 AM org.apache.catalina.core.ApplicationContext log
+[INFO] [talledLocalContainer] org.apache.catalina.core.ApplicationContext log
 [INFO] [talledLocalContainer] INFO: Initializing Spring root WebApplicationContext
 ...
 [INFO] [talledLocalContainer] INFO: Invoking @PostDeploy annotation in org.camunda.bpm.example.spring.servlet.pa.SpringServletProcessApplication
 [INFO] [talledLocalContainer] Starting testResolveBean processdefinition
-[INFO] [talledLocalContainer] Sep 23, 2021 9:35:01 AM org.camunda.bpm.example.spring.servlet.pa.ExampleBean invoke
+[INFO] [talledLocalContainer] org.camunda.bpm.example.spring.servlet.pa.ExampleBean invoke
 [INFO] [talledLocalContainer] INFO: org.camunda.bpm.example.spring.servlet.pa.ExampleBean is currently invoked.
-[INFO] [talledLocalContainer] Sep 23, 2021 9:35:01 AM org.camunda.bpm.example.spring.servlet.pa.SpringServletProcessApplication startProcess
+[INFO] [talledLocalContainer] org.camunda.bpm.example.spring.servlet.pa.SpringServletProcessApplication startProcess
 [INFO] [talledLocalContainer] INFO: Starting testResolveBeanFromJobExecutor processdefinition
-[INFO] [talledLocalContainer] Sep 23, 2021 9:35:01 AM org.camunda.bpm.example.spring.servlet.pa.ExampleDelegateBean execute
+[INFO] [talledLocalContainer] org.camunda.bpm.example.spring.servlet.pa.ExampleDelegateBean execute
 [INFO] [talledLocalContainer] INFO: org.camunda.bpm.example.spring.servlet.pa.ExampleDelegateBean is currently invoked.
-[INFO] [talledLocalContainer] Sep 23, 2021 9:35:01 AM org.camunda.commons.logging.BaseLogger logInfo
+[INFO] [talledLocalContainer] AM org.camunda.commons.logging.BaseLogger logInfo
 [INFO] [talledLocalContainer] INFO: ENGINE-08050 Process application camunda-quickstart-spring-servlet-pa-tomcat successfully deployed
 ```

--- a/deployment/spring-servlet-pa-tomcat/pom.xml
+++ b/deployment/spring-servlet-pa-tomcat/pom.xml
@@ -9,8 +9,8 @@
 
   <properties>
     <camunda.version>7.19.0</camunda.version>
-    <spring.version>5.3.22</spring.version>
-    <tomcat.version>9.0.58</tomcat.version>
+    <spring.version>5.3.26</spring.version>
+    <tomcat.version>9.0.72</tomcat.version>
     <servlet-api.version>4.0.1</servlet-api.version>
     <h2.version>2.1.214</h2.version>
     <slf4j.version>1.7.32</slf4j.version>

--- a/deployment/spring-servlet-pa-wildfly/README.md
+++ b/deployment/spring-servlet-pa-wildfly/README.md
@@ -7,6 +7,9 @@ This example demonstrates how to deploy a Spring-powered Web application which
   * Uses a shared container managed Process Engine and Spring Beans as expression and delegate
     expression in the processes
 
+> **Note:** This project must be deployed on a WildFly server of version 26 or below, 
+> NOT the latest pre-packaged distribution which can be downloaded from https://camunda.com.
+
 ## Why is this example interesting?
 
 This example shows how to combine a `@ProcessApplication` class, a `processes.xml` and a Spring
@@ -60,19 +63,23 @@ dependency like:
 
 ## How to use it?
 
-  1. Checkout the project with Git;
-  2. Import the project into your IDE;
-  3. Build it with Maven, it will download the Camunda Platform WildFly distribution and execute
-     the included Arquillian test.
-  4. Watch out for this console log:
+1. Build it with Maven.
 
 ```bash
-10:08:29,411 INFO  [org.camunda.bpm.example.spring.servlet.pa.SpringServletProcessApplication] (MSC service thread 1-5) Invoking @PostDeploy annotation in org.camunda.bpm.example.spring.servlet.pa.SpringServletProcessApplication
+mvn clean verify
+```
+
+This will create a Camunda Platform WildFly distribution and execute the included Arquillian test.
+
+3. Watch out for this console log:
+
+```bash
+INFO  [org.camunda.bpm.example.spring.servlet.pa.SpringServletProcessApplication] (MSC service thread 1-5) Invoking @PostDeploy annotation in org.camunda.bpm.example.spring.servlet.pa.SpringServletProcessApplication
 Starting testResolveBean processdefinition
-10:08:29,437 INFO  [org.camunda.bpm.example.spring.servlet.pa.ExampleBean] (MSC service thread 1-5) org.camunda.bpm.example.spring.servlet.pa.ExampleBean is currently invoked.
-10:08:29,447 INFO  [org.camunda.bpm.example.spring.servlet.pa.SpringServletProcessApplication] (MSC service thread 1-5) Starting testResolveBeanFromJobExecutor processdefinition
-10:08:29,465 INFO  [org.camunda.bpm.example.spring.servlet.pa.ExampleDelegateBean] (pool-10-thread-7) org.camunda.bpm.example.spring.servlet.pa.ExampleDelegateBean is currently invoked.
+INFO  [org.camunda.bpm.example.spring.servlet.pa.ExampleBean] (MSC service thread 1-5) org.camunda.bpm.example.spring.servlet.pa.ExampleBean is currently invoked.
+INFO  [org.camunda.bpm.example.spring.servlet.pa.SpringServletProcessApplication] (MSC service thread 1-5) Starting testResolveBeanFromJobExecutor processdefinition
+INFO  [org.camunda.bpm.example.spring.servlet.pa.ExampleDelegateBean] (pool-10-thread-7) org.camunda.bpm.example.spring.servlet.pa.ExampleDelegateBean is currently invoked.
 ...
-10:59:54,041 INFO  [org.camunda.bpm.example.spring.servlet.pa.SpringServletProcessApplication] (MSC service thread 1-1) Invoking @PreUndeploy annotation in org.camunda.bpm.example.spring.servlet.pa.SpringServletProcessApplication
+INFO  [org.camunda.bpm.example.spring.servlet.pa.SpringServletProcessApplication] (MSC service thread 1-1) Invoking @PreUndeploy annotation in org.camunda.bpm.example.spring.servlet.pa.SpringServletProcessApplication
 Undeploying SpringServletProcessApplication-Example
 ```

--- a/deployment/spring-servlet-pa-wildfly/pom.xml
+++ b/deployment/spring-servlet-pa-wildfly/pom.xml
@@ -9,13 +9,13 @@
   
   <properties>
     <version.camunda>7.19.0</version.camunda>
-    <version.spring>5.3.22</version.spring>
+    <version.spring>5.3.26</version.spring>
     <version.wildfly>26.0.1.Final</version.wildfly>
     <version.servlet-api.javax>4.0.1</version.servlet-api.javax>
 
     <version.wildfly.container.adapter>2.2.0.Final</version.wildfly.container.adapter>
     <version.arquillian>1.1.10.Final</version.arquillian>
-    <version.junit>4.13.1</version.junit>
+    <version.junit>4.13.2</version.junit>
 
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -158,13 +158,14 @@
               <failOnError>false</failOnError>
             </configuration>
           </plugin>
-          <!-- unpack Camunda Platform wildfly distro -->
+          <!-- unpack WildFly server and Camunda Platform WildFly 26 modules -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
+            <version>3.5.0</version>
             <executions>
               <execution>
-                <id>unpack-server</id>
+                <id>unpack-server-modules</id>
                 <phase>generate-resources</phase>
                 <goals>
                   <goal>unpack</goal>
@@ -173,14 +174,52 @@
                 <configuration>
                   <artifactItems>
                     <artifactItem>
+                      <groupId>org.wildfly</groupId>
+                      <artifactId>wildfly-dist</artifactId>
+                      <version>${version.wildfly}</version>
+                      <type>tar.gz</type>
+                      <overWrite>true</overWrite>
+                      <outputDirectory>${project.build.directory}/wildfly/server</outputDirectory>
+                      <excludes>**/h2database/**</excludes>
+                    </artifactItem>
+                    <artifactItem>
                       <groupId>org.camunda.bpm.wildfly</groupId>
-                      <artifactId>camunda-bpm-wildfly</artifactId>
+                      <artifactId>camunda-wildfly26-modules</artifactId>
                       <version>${version.camunda}</version>
                       <type>tar.gz</type>
                       <overWrite>true</overWrite>
-                      <outputDirectory>${project.build.directory}/wildfly</outputDirectory>
+                      <outputDirectory>${project.build.directory}/wildfly/server/wildfly-${version.wildfly}/modules</outputDirectory>
+                      <excludes>**/META-INF/**</excludes>
                     </artifactItem>
                   </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <configuration>
+              <delimiters>
+                <delimiter>${*}</delimiter>
+              </delimiters>
+              <useDefaultDelimiters>false</useDefaultDelimiters>
+            </configuration>
+            <executions>
+              <execution>
+                <id>copy-server-resources</id>
+                <phase>generate-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <resources>
+                    <resource>
+                      <directory>src/test/server</directory>
+                    </resource>
+                  </resources>
+                  <overwrite>true</overwrite>
+                  <outputDirectory>${project.build.directory}/wildfly/server/wildfly-${version.wildfly}/</outputDirectory>
                 </configuration>
               </execution>
             </executions>

--- a/deployment/spring-servlet-pa-wildfly/src/test/server/standalone/configuration/standalone.xml
+++ b/deployment/spring-servlet-pa-wildfly/src/test/server/standalone/configuration/standalone.xml
@@ -1,0 +1,614 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<server xmlns="urn:jboss:domain:19.0">
+    <extensions>
+        <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.connector"/>
+        <extension module="org.jboss.as.deployment-scanner"/>
+        <extension module="org.jboss.as.ee"/>
+        <extension module="org.jboss.as.ejb3"/>
+        <extension module="org.jboss.as.jaxrs"/>
+        <extension module="org.jboss.as.jdr"/>
+        <extension module="org.jboss.as.jmx"/>
+        <extension module="org.jboss.as.jpa"/>
+        <extension module="org.jboss.as.jsf"/>
+        <extension module="org.jboss.as.logging"/>
+        <extension module="org.jboss.as.mail"/>
+        <extension module="org.jboss.as.naming"/>
+        <extension module="org.jboss.as.pojo"/>
+        <extension module="org.jboss.as.remoting"/>
+        <extension module="org.jboss.as.sar"/>
+        <extension module="org.jboss.as.transactions"/>
+        <extension module="org.jboss.as.webservices"/>
+        <extension module="org.jboss.as.weld"/>
+        <extension module="org.wildfly.extension.batch.jberet"/>
+        <extension module="org.wildfly.extension.bean-validation"/>
+        <extension module="org.wildfly.extension.clustering.web"/>
+        <extension module="org.wildfly.extension.core-management"/>
+        <extension module="org.wildfly.extension.discovery"/>
+        <extension module="org.wildfly.extension.ee-security"/>
+        <extension module="org.wildfly.extension.elytron"/>
+        <extension module="org.wildfly.extension.elytron-oidc-client"/>
+        <extension module="org.wildfly.extension.health"/>
+        <extension module="org.wildfly.extension.io"/>
+        <extension module="org.wildfly.extension.metrics"/>
+        <extension module="org.wildfly.extension.microprofile.config-smallrye"/>
+        <extension module="org.wildfly.extension.microprofile.jwt-smallrye"/>
+        <extension module="org.wildfly.extension.microprofile.opentracing-smallrye"/>
+        <extension module="org.wildfly.extension.request-controller"/>
+        <extension module="org.wildfly.extension.security.manager"/>
+        <extension module="org.wildfly.extension.undertow"/>
+        <extension module="org.camunda.bpm.wildfly.camunda-wildfly-subsystem"/>
+    </extensions>
+    <management>
+        <audit-log>
+            <formatters>
+                <json-formatter name="json-formatter"/>
+            </formatters>
+            <handlers>
+                <file-handler name="file" formatter="json-formatter" path="audit-log.log" relative-to="jboss.server.data.dir"/>
+            </handlers>
+            <logger log-boot="true" log-read-only="false" enabled="false">
+                <handlers>
+                    <handler name="file"/>
+                </handlers>
+            </logger>
+        </audit-log>
+        <management-interfaces>
+            <http-interface http-authentication-factory="management-http-authentication">
+                <http-upgrade enabled="true" sasl-authentication-factory="management-sasl-authentication"/>
+                <socket-binding http="management-http"/>
+            </http-interface>
+        </management-interfaces>
+        <access-control provider="simple">
+            <role-mapping>
+                <role name="SuperUser">
+                    <include>
+                        <user name="$local"/>
+                    </include>
+                </role>
+            </role-mapping>
+        </access-control>
+    </management>
+    <profile>
+        <subsystem xmlns="urn:jboss:domain:logging:8.0">
+            <console-handler name="CONSOLE">
+                <level name="INFO"/>
+                <formatter>
+                    <named-formatter name="COLOR-PATTERN"/>
+                </formatter>
+            </console-handler>
+            <periodic-rotating-file-handler name="FILE" autoflush="true">
+                <formatter>
+                    <named-formatter name="PATTERN"/>
+                </formatter>
+                <file relative-to="jboss.server.log.dir" path="server.log"/>
+                <suffix value=".yyyy-MM-dd"/>
+                <append value="true"/>
+            </periodic-rotating-file-handler>
+            <logger category="com.arjuna">
+                <level name="WARN"/>
+            </logger>
+            <logger category="io.jaegertracing.Configuration">
+                <level name="WARN"/>
+            </logger>
+            <logger category="org.jboss.as.config">
+                <level name="DEBUG"/>
+            </logger>
+            <logger category="sun.rmi">
+                <level name="WARN"/>
+            </logger>
+            <root-logger>
+                <level name="INFO"/>
+                <handlers>
+                    <handler name="CONSOLE"/>
+                    <handler name="FILE"/>
+                </handlers>
+            </root-logger>
+            <formatter name="PATTERN">
+                <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+            </formatter>
+            <formatter name="COLOR-PATTERN">
+                <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+            </formatter>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:batch-jberet:2.0">
+            <default-job-repository name="in-memory"/>
+            <default-thread-pool name="batch"/>
+            <job-repository name="in-memory">
+                <in-memory/>
+            </job-repository>
+            <thread-pool name="batch">
+                <max-threads count="10"/>
+                <keepalive-time time="30" unit="seconds"/>
+            </thread-pool>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:core-management:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:datasources:6.0">
+            <datasources>
+                <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true" statistics-enabled="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}">
+                    <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+                    <driver>h2</driver>
+                    <security>
+                        <user-name>sa</user-name>
+                        <password>sa</password>
+                    </security>
+                </datasource>
+                <datasource jndi-name="java:jboss/datasources/ProcessEngine" pool-name="ProcessEngine" enabled="true" use-java-context="true" jta="true" use-ccm="true">
+                    <connection-url>jdbc:h2:./camunda-h2-dbs/process-engine;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+                    <driver>h2</driver>
+                    <transaction-isolation>TRANSACTION_READ_COMMITTED</transaction-isolation>
+                    <security>
+                        <user-name>sa</user-name>
+                        <password>sa</password>
+                    </security>
+                </datasource>
+                <drivers>
+                    <driver name="h2" module="com.h2database.h2">
+                        <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
+                    </driver>
+                </drivers>
+            </datasources>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:deployment-scanner:2.0">
+            <deployment-scanner path="deployments" relative-to="jboss.server.base.dir" scan-interval="5000" runtime-failure-causes-rollback="${jboss.deployment.scanner.rollback.on.failure:false}"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:discovery:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:distributable-web:2.0" default-session-management="default" default-single-sign-on-management="default">
+            <infinispan-session-management name="default" cache-container="web" granularity="SESSION">
+                <local-affinity/>
+            </infinispan-session-management>
+            <infinispan-single-sign-on-management name="default" cache-container="web" cache="sso"/>
+            <local-routing/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:ee:6.0">
+            <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
+            <concurrent>
+                <context-services>
+                    <context-service name="default" jndi-name="java:jboss/ee/concurrency/context/default" use-transaction-setup-provider="true"/>
+                </context-services>
+                <managed-thread-factories>
+                    <managed-thread-factory name="default" jndi-name="java:jboss/ee/concurrency/factory/default" context-service="default"/>
+                </managed-thread-factories>
+                <managed-executor-services>
+                    <managed-executor-service name="default" jndi-name="java:jboss/ee/concurrency/executor/default" context-service="default" hung-task-termination-period="0" hung-task-threshold="60000" keepalive-time="5000"/>
+                </managed-executor-services>
+                <managed-scheduled-executor-services>
+                    <managed-scheduled-executor-service name="default" jndi-name="java:jboss/ee/concurrency/scheduler/default" context-service="default" hung-task-termination-period="0" hung-task-threshold="60000" keepalive-time="3000"/>
+                </managed-scheduled-executor-services>
+            </concurrent>
+            <default-bindings context-service="java:jboss/ee/concurrency/context/default" datasource="java:jboss/datasources/ExampleDS" managed-executor-service="java:jboss/ee/concurrency/executor/default" managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default" managed-thread-factory="java:jboss/ee/concurrency/factory/default"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:ee-security:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:ejb3:9.0">
+            <session-bean>
+                <stateless>
+                    <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
+                </stateless>
+                <stateful default-access-timeout="5000" cache-ref="simple" passivation-disabled-cache-ref="simple"/>
+                <singleton default-access-timeout="5000"/>
+            </session-bean>
+            <pools>
+                <bean-instance-pools>
+                    <strict-max-pool name="mdb-strict-max-pool" derive-size="from-cpu-count" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
+                    <strict-max-pool name="slsb-strict-max-pool" derive-size="from-worker-pools" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
+                </bean-instance-pools>
+            </pools>
+            <caches>
+                <cache name="simple"/>
+                <cache name="distributable" passivation-store-ref="infinispan" aliases="passivating clustered"/>
+            </caches>
+            <passivation-stores>
+                <passivation-store name="infinispan" cache-container="ejb" max-size="10000"/>
+            </passivation-stores>
+            <async thread-pool-name="default"/>
+            <timer-service thread-pool-name="default" default-data-store="default-file-store">
+                <data-stores>
+                    <file-data-store name="default-file-store" path="timer-service-data" relative-to="jboss.server.data.dir"/>
+                </data-stores>
+            </timer-service>
+            <remote cluster="ejb" connectors="http-remoting-connector" thread-pool-name="default">
+                <channel-creation-options>
+                    <option name="MAX_OUTBOUND_MESSAGES" value="1234" type="remoting"/>
+                </channel-creation-options>
+            </remote>
+            <thread-pools>
+                <thread-pool name="default">
+                    <max-threads count="10"/>
+                    <keepalive-time time="60" unit="seconds"/>
+                </thread-pool>
+            </thread-pools>
+            <default-security-domain value="other"/>
+            <application-security-domains>
+                <application-security-domain name="other" security-domain="ApplicationDomain"/>
+            </application-security-domains>
+            <default-missing-method-permissions-deny-access value="true"/>
+            <statistics enabled="${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}"/>
+            <log-system-exceptions value="true"/>
+        </subsystem>
+        <subsystem xmlns="urn:wildfly:elytron:15.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
+            <providers>
+                <aggregate-providers name="combined-providers">
+                    <providers name="elytron"/>
+                    <providers name="openssl"/>
+                </aggregate-providers>
+                <provider-loader name="elytron" module="org.wildfly.security.elytron"/>
+                <provider-loader name="openssl" module="org.wildfly.openssl"/>
+            </providers>
+            <audit-logging>
+                <file-audit-log name="local-audit" path="audit.log" relative-to="jboss.server.log.dir" format="JSON"/>
+            </audit-logging>
+            <security-domains>
+                <security-domain name="ManagementDomain" default-realm="ManagementRealm" permission-mapper="default-permission-mapper">
+                    <realm name="ManagementRealm" role-decoder="groups-to-roles"/>
+                    <realm name="local" role-mapper="super-user-mapper"/>
+                </security-domain>
+                <security-domain name="ApplicationDomain" default-realm="ApplicationRealm" permission-mapper="default-permission-mapper">
+                    <realm name="ApplicationRealm" role-decoder="groups-to-roles"/>
+                    <realm name="local"/>
+                </security-domain>
+            </security-domains>
+            <security-realms>
+                <identity-realm name="local" identity="$local"/>
+                <properties-realm name="ApplicationRealm">
+                    <users-properties path="application-users.properties" relative-to="jboss.server.config.dir" digest-realm-name="ApplicationRealm"/>
+                    <groups-properties path="application-roles.properties" relative-to="jboss.server.config.dir"/>
+                </properties-realm>
+                <properties-realm name="ManagementRealm">
+                    <users-properties path="mgmt-users.properties" relative-to="jboss.server.config.dir" digest-realm-name="ManagementRealm"/>
+                    <groups-properties path="mgmt-groups.properties" relative-to="jboss.server.config.dir"/>
+                </properties-realm>
+            </security-realms>
+            <mappers>
+                <simple-permission-mapper name="default-permission-mapper" mapping-mode="first">
+                    <permission-mapping>
+                        <principal name="anonymous"/>
+                        <permission-set name="default-permissions"/>
+                    </permission-mapping>
+                    <permission-mapping match-all="true">
+                        <permission-set name="login-permission"/>
+                        <permission-set name="default-permissions"/>
+                    </permission-mapping>
+                </simple-permission-mapper>
+                <constant-realm-mapper name="local" realm-name="local"/>
+                <simple-role-decoder name="groups-to-roles" attribute="groups"/>
+                <constant-role-mapper name="super-user-mapper">
+                    <role name="SuperUser"/>
+                </constant-role-mapper>
+            </mappers>
+            <permission-sets>
+                <permission-set name="login-permission">
+                    <permission class-name="org.wildfly.security.auth.permission.LoginPermission"/>
+                </permission-set>
+                <permission-set name="default-permissions">
+                    <permission class-name="org.wildfly.extension.batch.jberet.deployment.BatchPermission" module="org.wildfly.extension.batch.jberet" target-name="*"/>
+                    <permission class-name="org.wildfly.transaction.client.RemoteTransactionPermission" module="org.wildfly.transaction.client"/>
+                    <permission class-name="org.jboss.ejb.client.RemoteEJBPermission" module="org.jboss.ejb-client"/>
+                </permission-set>
+            </permission-sets>
+            <http>
+                <http-authentication-factory name="management-http-authentication" security-domain="ManagementDomain" http-server-mechanism-factory="global">
+                    <mechanism-configuration>
+                        <mechanism mechanism-name="DIGEST">
+                            <mechanism-realm realm-name="ManagementRealm"/>
+                        </mechanism>
+                    </mechanism-configuration>
+                </http-authentication-factory>
+                <http-authentication-factory name="application-http-authentication" security-domain="ApplicationDomain" http-server-mechanism-factory="global">
+                    <mechanism-configuration>
+                        <mechanism mechanism-name="BASIC">
+                            <mechanism-realm realm-name="ApplicationRealm"/>
+                        </mechanism>
+                    </mechanism-configuration>
+                </http-authentication-factory>
+                <provider-http-server-mechanism-factory name="global"/>
+            </http>
+            <sasl>
+                <sasl-authentication-factory name="management-sasl-authentication" sasl-server-factory="configured" security-domain="ManagementDomain">
+                    <mechanism-configuration>
+                        <mechanism mechanism-name="JBOSS-LOCAL-USER" realm-mapper="local"/>
+                        <mechanism mechanism-name="DIGEST-MD5">
+                            <mechanism-realm realm-name="ManagementRealm"/>
+                        </mechanism>
+                    </mechanism-configuration>
+                </sasl-authentication-factory>
+                <sasl-authentication-factory name="application-sasl-authentication" sasl-server-factory="configured" security-domain="ApplicationDomain">
+                    <mechanism-configuration>
+                        <mechanism mechanism-name="JBOSS-LOCAL-USER" realm-mapper="local"/>
+                        <mechanism mechanism-name="DIGEST-MD5">
+                            <mechanism-realm realm-name="ApplicationRealm"/>
+                        </mechanism>
+                    </mechanism-configuration>
+                </sasl-authentication-factory>
+                <configurable-sasl-server-factory name="configured" sasl-server-factory="elytron">
+                    <properties>
+                        <property name="wildfly.sasl.local-user.default-user" value="$local"/>
+                        <property name="wildfly.sasl.local-user.challenge-path" value="${jboss.server.temp.dir}/auth"/>
+                    </properties>
+                </configurable-sasl-server-factory>
+                <mechanism-provider-filtering-sasl-server-factory name="elytron" sasl-server-factory="global">
+                    <filters>
+                        <filter provider-name="WildFlyElytron"/>
+                    </filters>
+                </mechanism-provider-filtering-sasl-server-factory>
+                <provider-sasl-server-factory name="global"/>
+            </sasl>
+            <tls>
+                <key-stores>
+                    <key-store name="applicationKS">
+                        <credential-reference clear-text="password"/>
+                        <implementation type="JKS"/>
+                        <file path="application.keystore" relative-to="jboss.server.config.dir"/>
+                    </key-store>
+                </key-stores>
+                <key-managers>
+                    <key-manager name="applicationKM" key-store="applicationKS" generate-self-signed-certificate-host="localhost">
+                        <credential-reference clear-text="password"/>
+                    </key-manager>
+                </key-managers>
+                <server-ssl-contexts>
+                    <server-ssl-context name="applicationSSC" key-manager="applicationKM"/>
+                </server-ssl-contexts>
+            </tls>
+        </subsystem>
+        <subsystem xmlns="urn:wildfly:elytron-oidc-client:1.0"/>
+        <subsystem xmlns="urn:wildfly:health:1.0" security-enabled="false"/>
+        <subsystem xmlns="urn:jboss:domain:infinispan:13.0">
+            <cache-container name="ejb" default-cache="passivation" marshaller="PROTOSTREAM" aliases="sfsb" modules="org.wildfly.clustering.ejb.infinispan">
+                <local-cache name="passivation">
+                    <expiration interval="0"/>
+                    <file-store passivation="true" purge="false"/>
+                </local-cache>
+            </cache-container>
+            <cache-container name="web" default-cache="passivation" marshaller="PROTOSTREAM" modules="org.wildfly.clustering.web.infinispan">
+                <local-cache name="passivation">
+                    <expiration interval="0"/>
+                    <file-store passivation="true" purge="false"/>
+                </local-cache>
+                <local-cache name="sso">
+                    <expiration interval="0"/>
+                </local-cache>
+            </cache-container>
+            <cache-container name="server" default-cache="default" marshaller="PROTOSTREAM" modules="org.wildfly.clustering.server">
+                <local-cache name="default">
+                    <expiration interval="0"/>
+                </local-cache>
+            </cache-container>
+            <cache-container name="hibernate" marshaller="JBOSS" modules="org.infinispan.hibernate-cache">
+                <local-cache name="entity">
+                    <heap-memory size="10000"/>
+                    <expiration max-idle="100000"/>
+                </local-cache>
+                <local-cache name="local-query">
+                    <heap-memory size="10000"/>
+                    <expiration max-idle="100000"/>
+                </local-cache>
+                <local-cache name="timestamps">
+                    <expiration interval="0"/>
+                </local-cache>
+                <local-cache name="pending-puts">
+                    <expiration max-idle="60000"/>
+                </local-cache>
+            </cache-container>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:io:3.0">
+            <worker name="default"/>
+            <buffer-pool name="default"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jaxrs:2.0"/>
+        <subsystem xmlns="urn:jboss:domain:jca:5.0">
+            <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
+            <bean-validation enabled="true"/>
+            <default-workmanager>
+                <short-running-threads>
+                    <core-threads count="50"/>
+                    <queue-length count="50"/>
+                    <max-threads count="50"/>
+                    <keepalive-time time="10" unit="seconds"/>
+                </short-running-threads>
+                <long-running-threads>
+                    <core-threads count="50"/>
+                    <queue-length count="50"/>
+                    <max-threads count="50"/>
+                    <keepalive-time time="10" unit="seconds"/>
+                </long-running-threads>
+            </default-workmanager>
+            <cached-connection-manager/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jdr:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+            <expose-resolved-model/>
+            <expose-expression-model/>
+            <remoting-connector/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jpa:1.1">
+            <jpa default-extended-persistence-inheritance="DEEP"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jsf:1.1"/>
+        <subsystem xmlns="urn:jboss:domain:mail:4.0">
+            <mail-session name="default" jndi-name="java:jboss/mail/Default">
+                <smtp-server outbound-socket-binding-ref="mail-smtp"/>
+            </mail-session>
+        </subsystem>
+        <subsystem xmlns="urn:wildfly:metrics:1.0" security-enabled="false" exposed-subsystems="*" prefix="${wildfly.metrics.prefix:wildfly}"/>
+        <subsystem xmlns="urn:wildfly:microprofile-config-smallrye:1.0"/>
+        <subsystem xmlns="urn:wildfly:microprofile-jwt-smallrye:1.0"/>
+        <subsystem xmlns="urn:wildfly:microprofile-opentracing-smallrye:3.0" default-tracer="jaeger">
+            <jaeger-tracer name="jaeger">
+                <sampler-configuration sampler-type="const" sampler-param="1.0"/>
+            </jaeger-tracer>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:naming:2.0">
+            <remote-naming/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:pojo:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:remoting:4.0">
+            <http-connector name="http-remoting-connector" connector-ref="default" sasl-authentication-factory="application-sasl-authentication"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:request-controller:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:resource-adapters:6.0"/>
+        <subsystem xmlns="urn:jboss:domain:sar:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:security-manager:1.0">
+            <deployment-permissions>
+                <maximum-set>
+                    <permission class="java.security.AllPermission"/>
+                </maximum-set>
+            </deployment-permissions>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:transactions:6.0">
+            <core-environment node-identifier="${jboss.tx.node.id:1}">
+                <process-id>
+                    <uuid/>
+                </process-id>
+            </core-environment>
+            <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
+            <coordinator-environment statistics-enabled="${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}"/>
+            <object-store path="tx-object-store" relative-to="jboss.server.data.dir"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:undertow:12.0" default-server="default-server" default-virtual-host="default-host" default-servlet-container="default" default-security-domain="other" statistics-enabled="${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}">
+            <buffer-cache name="default"/>
+            <server name="default-server">
+                <http-listener name="default" socket-binding="http" redirect-socket="https" enable-http2="true"/>
+                <https-listener name="https" socket-binding="https" ssl-context="applicationSSC" enable-http2="true"/>
+                <host name="default-host" alias="localhost">
+                    <location name="/" handler="welcome-content"/>
+                    <http-invoker http-authentication-factory="application-http-authentication"/>
+                </host>
+            </server>
+            <servlet-container name="default">
+                <jsp-config/>
+                <websockets/>
+            </servlet-container>
+            <handlers>
+                <file name="welcome-content" path="${jboss.home.dir}/welcome-content"/>
+            </handlers>
+            <application-security-domains>
+                <application-security-domain name="other" security-domain="ApplicationDomain"/>
+            </application-security-domains>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:webservices:2.0" statistics-enabled="${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}">
+            <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
+            <endpoint-config name="Standard-Endpoint-Config"/>
+            <endpoint-config name="Recording-Endpoint-Config">
+                <pre-handler-chain name="recording-handlers" protocol-bindings="##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM">
+                    <handler name="RecordingHandler" class="org.jboss.ws.common.invocation.RecordingServerHandler"/>
+                </pre-handler-chain>
+            </endpoint-config>
+            <client-config name="Standard-Client-Config"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:weld:4.0"/>
+        <subsystem xmlns="urn:org.camunda.bpm.jboss:1.1">
+            <process-engines>
+                <process-engine name="default" default="true">
+                    <datasource>java:jboss/datasources/ProcessEngine</datasource>
+                    <history-level>full</history-level>
+                    <properties>
+                        <property name="jobExecutorAcquisitionName">default</property>
+                        <property name="isAutoSchemaUpdate">true</property>
+                        <property name="authorizationEnabled">true</property>
+                        <property name="jobExecutorDeploymentAware">true</property>
+                        <property name="historyCleanupBatchWindowStartTime">00:01</property>
+                    </properties>
+                    <plugins>
+
+                        <!-- plugin enabling Process Application event listener support -->
+                        <plugin>
+                            <class>org.camunda.bpm.application.impl.event.ProcessApplicationEventListenerPlugin</class>
+                        </plugin>
+
+                        <!-- plugin enabling integration of camunda Spin -->
+                        <plugin>
+                            <class>org.camunda.spin.plugin.impl.SpinProcessEnginePlugin</class>
+                        </plugin>
+
+                        <!-- plugin enabling connect support -->
+                        <plugin>
+                            <class>org.camunda.connect.plugin.impl.ConnectProcessEnginePlugin</class>
+                        </plugin>
+
+                        <!-- LDAP CONFIGURATION -->
+                        <!-- Uncomment this section in order to enable LDAP support for this process engine -->
+                        <!-- Adjust configuration, see ( http://docs.camunda.org/latest/guides/user-guide/#process-engine-identity-service-the-ldap-identity-service ) -->
+                        <!--
+                            <plugin>
+                                <class>org.camunda.bpm.identity.impl.ldap.plugin.LdapIdentityProviderPlugin</class>
+
+                                <properties>
+                                    <property name="serverUrl">ldaps://localhost:4334/</property>
+                                    <property name="acceptUntrustedCertificates">false</property>
+                                    <property name="managerDn">uid=jonny,ou=office-berlin,o=camunda,c=org</property>
+                                    <property name="managerPassword">s3cr3t</property>
+
+                                    <property name="baseDn">o=camunda,c=org</property>
+
+                                    <property name="userSearchBase">ou=employees</property>
+                                    <property name="userSearchFilter">(objectclass=person)</property>
+
+                                    <property name="userIdAttribute">uid</property>
+                                    <property name="userFirstnameAttribute">cn</property>
+                                    <property name="userLastnameAttribute">sn</property>
+                                    <property name="userEmailAttribute">mail</property>
+                                    <property name="userPasswordAttribute">userpassword</property>
+
+                                    <property name="groupSearchBase">ou=roles</property>
+                                    <property name="groupSearchFilter">(objectclass=groupOfNames)</property>
+                                    <property name="groupIdAttribute">cn</property>
+                                    <property name="groupNameAttribute">cn</property>
+
+                                    <property name="groupMemberAttribute">member</property>
+                                    <property name="sortControlSupported">false</property>
+                                </properties>
+                            </plugin>
+                        -->
+
+                        <!-- LDAP CONFIGURATION -->
+                        <!-- The following plugin allows you to grant administrator authorizations to an existing LDAP user -->
+                        <!--
+                            <plugin>
+                                <class>org.camunda.bpm.engine.impl.plugin.AdministratorAuthorizationPlugin</class>
+                                <properties>
+                                    <property name="administratorUserName">admin</property>
+                                </properties>
+                             </plugin>
+                         -->
+                    </plugins>
+                </process-engine>
+            </process-engines>
+            <job-executor>
+                <core-threads>3</core-threads>
+                <max-threads>5</max-threads>
+                <queue-length>10</queue-length>
+                <job-acquisitions>
+                    <job-acquisition name="default">
+                        <properties>
+                            <property name="lockTimeInMillis">300000</property>
+                            <property name="waitTimeInMillis">5000</property>
+                            <property name="maxJobsPerAcquisition">3</property>
+                        </properties>
+                    </job-acquisition>
+                </job-acquisitions>
+            </job-executor>
+        </subsystem>
+    </profile>
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.bind.address.management:127.0.0.1}"/>
+        </interface>
+        <interface name="public">
+            <inet-address value="${jboss.bind.address:127.0.0.1}"/>
+        </interface>
+    </interfaces>
+    <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
+        <socket-binding name="ajp" port="${jboss.ajp.port:8009}"/>
+        <socket-binding name="http" port="${jboss.http.port:8080}"/>
+        <socket-binding name="https" port="${jboss.https.port:8443}"/>
+        <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
+        <socket-binding name="txn-recovery-environment" port="4712"/>
+        <socket-binding name="txn-status-manager" port="4713"/>
+        <outbound-socket-binding name="mail-smtp">
+            <remote-destination host="localhost" port="25"/>
+        </outbound-socket-binding>
+    </socket-binding-group>
+</server>

--- a/deployment/spring-wildfly-non-pa/README.md
+++ b/deployment/spring-wildfly-non-pa/README.md
@@ -81,9 +81,9 @@ We also add an entry to the manifest, so that the Process Engine classes are add
 
 ## How to use it?
 
-  1. Build it with Maven
-  2. Deploy it to WildFly (download it from [here][1])
-  3. Watch out for this console log:
+1. Build it with Maven.
+2. Deploy it to WildFly 26 and below (install as described [here][1]).
+3. Watch out for this console log:
 
 ```bash
 Hi there!
@@ -92,4 +92,14 @@ The engine is named default.
 There are currently 0 processes deployed on this engine.
 ```
 
-[1]: https://downloads.camunda.cloud/release/camunda-bpm/wildfly/
+## Moving to Jakarta API
+
+If you would like to deploy this on a Jakarta EE 9+ server like WildFly 27 and beyond, perform the following steps:
+
+1. Bump the `spring.version` in the `pom.xml` to `6.x.y` (find the latest version [here][2]).
+2. Build it with Maven (needs JDK 17+).
+3. Deploy it to WildFly (download from [here][3]).
+
+[1]: https://docs.camunda.org/manual/latest/installation/full/jboss/manual/
+[2]: https://central.sonatype.com/search?q=g%253Aorg.springframework%2520a%253Aspring-framework-bom
+[3]: https://downloads.camunda.cloud/release/camunda-bpm/wildfly/

--- a/deployment/spring-wildfly-non-pa/pom.xml
+++ b/deployment/spring-wildfly-non-pa/pom.xml
@@ -10,7 +10,7 @@
 
   <properties>
     <camunda.version>7.19.0</camunda.version>
-    <spring.version>5.3.22</spring.version>
+    <spring.version>5.3.26</spring.version>
     <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
 
     <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
* Introduces a new Jakarta EJB example.
* Adds migration hints to Jakarta API where applicable.
* Uses WildFly 26 modules where necessary.

closes https://github.com/camunda/camunda-bpm-platform/issues/2919