### PR TITLE
chore(quarkus): resolve warning

### DIFF
--- a/quarkus-extension/datasource-example/README.md
+++ b/quarkus-extension/datasource-example/README.md
@@ -56,7 +56,7 @@ Be aware that it’s not an _über-jar_ as the dependencies are copied into the 
 
 If you want to build an _über-jar_, execute the following command:
 ```shell script
-mvn clean package -Dquarkus.package.type=uber-jar
+mvn clean package -Dquarkus.package.jar.type=uber-jar
 ```
 
 The application is now runnable using `java -jar target/camunda-bpm-quarkus-example-datasource-1.0.0-SNAPSHOT-runner.jar`.


### PR DESCRIPTION
Resolve quarkus warning when building the uber-jar:

```
WARN  [io.qua.dep.configuration] (main) Configuration property 'quarkus.package.type' has been deprecated and replaced by: [quarkus.package.jar.enabled, quarkus.package.jar.type, quarkus.native.enabled, quarkus.native.sources-only]
```